### PR TITLE
Fix typo in 01-08-Functions

### DIFF
--- a/Module01/01-08-Functions.ipynb
+++ b/Module01/01-08-Functions.ipynb
@@ -134,7 +134,7 @@
    "source": [
     "g = function(x){\n",
     "    ## Use vectorized ifelse to return the value or the missing value, NA\n",
-    "    ifelse(x != 0,(12.2*x)^2, NA)\n",
+    "    ifelse(x != 0,(12/(2*x))^2, NA)\n",
     "}\n",
     "\n",
     "## Construct the data frame.\n",


### PR DESCRIPTION
Pretty sure this should be changed as `(12.2*x) ^2` is defined for `x = 0`